### PR TITLE
Add --prepend and --append to batch-caption.py

### DIFF
--- a/scripts/batch-caption.py
+++ b/scripts/batch-caption.py
@@ -42,8 +42,8 @@ parser.add_argument("--top-k", type=lambda x: none_or_type(x, int), default=None
 parser.add_argument("--max-new-tokens", type=int, default=256, help="Maximum length of the generated caption (in tokens)")
 parser.add_argument("--num-workers", type=int, default=4, help="Number of workers loading images in parallel")
 parser.add_argument("--model", type=str, default="fancyfeast/llama-joycaption-alpha-two-hf-llava", help="Model to use")
-parser.add_argument("--prepend", type=str, help="String to prepend to captions")
-parser.add_argument("--append", type=str, help="String to append to captions")
+parser.add_argument("--prepend", type=str, default="", help="String to prepend to all captions")
+parser.add_argument("--append", type=str, default="", help="String to append to all captions")
 
 
 PIL.Image.MAX_IMAGE_PIXELS = 933120000   # Quiets Pillow from giving warnings on really large images (WARNING: Exposes a risk of DoS from malicious images)
@@ -129,8 +129,7 @@ def main():
 		captions = [c.strip() for c in captions]
 
 		for path, caption in zip(batch['paths'], captions):
-		
-			write_caption(Path(path), caption, args.prepend, args.append)
+			write_caption(Path(path), args.prepend + caption + args.append)
 		pbar.update(len(captions))
 
 
@@ -153,7 +152,7 @@ def trim_off_prompt(input_ids: list[int], eoh_id: int, eot_id: int) -> list[int]
 	return input_ids[:i]
 
 
-def write_caption(image_path: Path, caption: str, prepend: str, append: str):
+def write_caption(image_path: Path, caption: str):
 	caption_path = image_path.with_suffix(".txt")
 
 	try:
@@ -166,9 +165,7 @@ def write_caption(image_path: Path, caption: str, prepend: str, append: str):
 		return
 	
 	try:
-		if prepend is not None and len(prepend) > 0: os.write(f, prepend.encode("utf-8"))
 		os.write(f, caption.encode("utf-8"))
-		if append is not None and len(append) > 0: os.write(f, append.encode("utf-8"))
 		os.close(f)
 	except Exception as e:
 		logging.error(f"Failed to write caption to '{caption_path}': {e}")


### PR DESCRIPTION
Add additional prepend and append options so users can easily insert character / style tags when training LoRAs etc.