### PR TITLE
Fix int8 check

### DIFF
--- a/gradio-app/app.py
+++ b/gradio-app/app.py
@@ -322,7 +322,7 @@ def load_model(quant: str, status: gr.HTML | None = None):
 						print(f"[WARN] Liger kernel could not be applied: {e}")
 			else:
 				from transformers import BitsAndBytesConfig
-				if quant == "8bit":
+				if quant == "int8":
 					qnt_config = BitsAndBytesConfig(
 						load_in_8bit=True,
 						llm_int8_skip_modules=["vision_tower", "multi_modal_projector"],   # Transformer's Siglip implementation has bugs when quantized, so skip those.


### PR DESCRIPTION
It's defined as `int8` here but the code checked against `8bit` leading to `Unknown quantization type: int8` error.

https://github.com/fpgaminer/joycaption/blob/45f92d2a2670353d9de1fb2cd081330f492fba88/gradio-app/app.py#L662